### PR TITLE
Make timezone a host_var

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -8,6 +8,8 @@ run_sshd: false
 use_x11: false
 
 # override these in host_vars
+host_timezone=America/Detroit
+
 install_git_homedir: false
 
 install_av: false

--- a/group_vars/all
+++ b/group_vars/all
@@ -8,7 +8,7 @@ run_sshd: false
 use_x11: false
 
 # override these in host_vars
-host_timezone=America/Detroit
+host_timezone: America/Detroit
 
 install_git_homedir: false
 

--- a/roles/void/tasks/main.yml
+++ b/roles/void/tasks/main.yml
@@ -83,7 +83,7 @@
     regexp: '^#?HARDWARECLOCK='
     line: 'HARDWARECLOCK=UTC'
 
-- name: set local timezone to America/Detroit
+- name: set local timezone
   become: yes
   lineinfile:
     backup: yes
@@ -91,7 +91,7 @@
     create: yes
     path: /etc/rc.conf
     regexp: '^#?TIMEZONE='
-    line: 'TIMEZONE=America/Detroit'
+    line: 'TIMEZONE={{host_timezone}}'
 
 - name: set terminal font
   become: yes


### PR DESCRIPTION
This makes `host_timezone` available as a variable that I can override in a host_var. That way I'm not required to live in Detroit :-P